### PR TITLE
Implement enough stubs and tests to create and drop a cassandra keyspace

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -34,10 +34,13 @@ object SlickBuild extends Build {
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
     val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
     val hikariCP = "com.zaxxer" % "HikariCP-java6" % "2.3.7"
-    val mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams)
+    val cassandra = "com.datastax.cassandra" % "cassandra-driver-core" % "2.2.0-rc3"
+    val curator = "org.apache.curator" % "curator-recipes" % "2.9.1"
+    val mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams, cassandra, curator)
     val h2 = "com.h2database" % "h2" % "1.4.187"
     val testDBs = Seq(
       h2,
+      cassandra,
       "org.xerial" % "sqlite-jdbc" % "3.8.7",
       "org.apache.derby" % "derby" % "10.9.1.0",
       "org.hsqldb" % "hsqldb" % "2.2.8",
@@ -329,7 +332,7 @@ object SlickBuild extends Build {
     settings(sharedSettings:_*)
     settings(
       name := "Slick-OsgiTests",
-      libraryDependencies ++= (Dependencies.h2 +: Dependencies.logback +: Dependencies.junit ++: Dependencies.reactiveStreams +: Dependencies.paxExam).map(_ % "test"),
+      libraryDependencies ++= (Dependencies.h2 +: Dependencies.cassandra +: Dependencies.logback +: Dependencies.junit ++: Dependencies.reactiveStreams +: Dependencies.paxExam).map(_ % "test"),
       unmanagedResourceDirectories in Test += (baseDirectory in aRootProject).value / "common-test-resources",
       fork in Test := true,
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s", "-a"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,6 +27,7 @@ object SlickBuild extends Build {
       val v = if(scalaVersion == "2.12.0-M2") "2.2.5-M2" else "2.2.4"
       "org.scalatest" %% "scalatest" % v
     }
+    val scalaMock = "org.scalamock" %% "scalamock-scalatest-support" % "3.2" % "test"
     val slf4j = "org.slf4j" % "slf4j-api" % "1.7.10"
     val logback = "ch.qos.logback" % "logback-classic" % "1.1.3"
     val typesafeConfig = "com.typesafe" % "config" % "1.2.1"
@@ -251,6 +252,8 @@ object SlickBuild extends Build {
       //scalacOptions in Compile += "-Yreify-copypaste",
       libraryDependencies ++=
         Dependencies.junit ++:
+        Dependencies.scalaTestFor(scalaVersion.value) +:
+        Dependencies.scalaMock +:
         (Dependencies.reactiveStreamsTCK % "test") +:
         (Dependencies.logback +: Dependencies.testDBs).map(_ % "test") ++:
         (Dependencies.logback +: Dependencies.testDBs).map(_ % "codegen"),

--- a/slick-testkit/src/main/resources/testkit-reference.conf
+++ b/slick-testkit/src/main/resources/testkit-reference.conf
@@ -5,7 +5,7 @@
 testkit {
   # Use only the following DBs (or use all if not set)
   #testDBs = [h2mem, h2rownum, h2disk, hsqldbmem, hsqldbdisk, sqlitemem, sqlitedisk, derbymem, derbydisk, postgres, mysql, access, heap, cassandra]
-  testDBs = cassandra
+  testDBs = null
 
   # Store database files in this path (ignored by MySQL and in-memory databases)
   # absTestDir is computed from this and injected here for use in substitutions
@@ -109,4 +109,11 @@ mysql {
   create = CREATE DATABASE ${testDB}
   drop = DROP DATABASE IF EXISTS ${testDB}
   driver = com.mysql.jdbc.Driver
+}
+
+cassandra {
+    zookeeper = "127.0.0.1"
+    zNode     = "/cassandra"
+    timeout   = 60000
+    retryTime = 5000
 }

--- a/slick-testkit/src/main/resources/testkit-reference.conf
+++ b/slick-testkit/src/main/resources/testkit-reference.conf
@@ -112,7 +112,7 @@ mysql {
 }
 
 cassandra {
-    zookeeper = "127.0.0.1"
+    zookeeper = "127.0.0.1:2181"
     zNode     = "/cassandra"
     timeout   = 60000
     retryTime = 5000

--- a/slick-testkit/src/main/resources/testkit-reference.conf
+++ b/slick-testkit/src/main/resources/testkit-reference.conf
@@ -112,7 +112,6 @@ mysql {
 }
 
 cassandra {
-    zookeeper = "127.0.0.1:2181"
     zNode     = "/cassandra"
     timeout   = 60000
     retryTime = 5000

--- a/slick-testkit/src/main/resources/testkit-reference.conf
+++ b/slick-testkit/src/main/resources/testkit-reference.conf
@@ -4,8 +4,8 @@
 
 testkit {
   # Use only the following DBs (or use all if not set)
-  #testDBs = [h2mem, h2rownum, h2disk, hsqldbmem, hsqldbdisk, sqlitemem, sqlitedisk, derbymem, derbydisk, postgres, mysql, access, heap]
-  testDBs = null
+  #testDBs = [h2mem, h2rownum, h2disk, hsqldbmem, hsqldbdisk, sqlitemem, sqlitedisk, derbymem, derbydisk, postgres, mysql, access, heap, cassandra]
+  testDBs = cassandra
 
   # Store database files in this path (ignored by MySQL and in-memory databases)
   # absTestDir is computed from this and injected here for use in substitutions
@@ -45,6 +45,7 @@ testkit {
     ${testPackage}.TemplateTest
     ${testPackage}.TransactionTest
     ${testPackage}.UnionTest
+    ${testPackage}.KeyspaceTest
   ]
 }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/KeyspaceCreationTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/KeyspaceCreationTest.scala
@@ -1,0 +1,23 @@
+package com.typesafe.slick.testkit.tests
+
+import com.typesafe.slick.testkit.util.{CassandraTestDB, AsyncTest}
+
+class KeyspaceTest extends AsyncTest[CassandraTestDB] {
+  import tdb.profile.api._
+
+  def testKeyspaceCreation = {
+    val command = "CREATE KEYSPACE IF NOT EXISTS slicktest WITH replication = {'class':'SimpleStrategy', 'replication_factor':1};"
+    val action = SimpleDBIO(_.connection.execute(command))
+    for {
+      _ <- action
+    } yield ()
+  }
+
+  def testKeyspaceDrop = {
+    val command = "DROP KEYSPACE slicktest;"
+    val action = SimpleDBIO(_.connection.execute(command))
+    for {
+      _ <- action
+    } yield ()
+  }
+}

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TableCreationTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TableCreationTest.scala
@@ -1,0 +1,18 @@
+package com.typesafe.slick.testkit.tests
+
+import com.typesafe.slick.testkit.util.{CassandraTestDB, AsyncTest}
+
+class TableCreationTest extends AsyncTest[CassandraTestDB] {
+  import tdb.profile.api._
+
+  def testTableCreation = {
+    class TestTable(tag: Tag) extends Table[Int](tag, "TEST") {
+      def id = column[Int]("ID")
+      def * = id
+    }
+    val testTable = TableQuery(new TestTable(_))
+    for {
+      _ <- testTable.schema.create
+    } yield ()
+  }
+}

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/StandardTestDBs.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/StandardTestDBs.scala
@@ -125,7 +125,7 @@ object StandardTestDBs {
     val confName: String = "cassandra"
 
     def createDB(): slick.cassandra.CassandraBackend#DatabaseDef =
-      profile.backend.Database.forConfig("testConn", config)
+      profile.backend.Database.forConfig("", config)
 
     def dropUserArtifacts(implicit session: slick.cassandra.CassandraBackend#SessionDef): Unit = {
       session.close()

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/StandardTestDBs.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/StandardTestDBs.scala
@@ -9,6 +9,8 @@ import slick.memory.MemoryProfile
 import slick.jdbc.{SimpleJdbcAction, ResultSetAction, H2Profile, HsqldbProfile, MySQLProfile, DerbyProfile, PostgresProfile, SQLiteProfile}
 import slick.jdbc.GetResult._
 import slick.jdbc.meta.MTable
+import slick.cassandra.CassandraProfile
+import slick.sql.SqlProfile
 import org.junit.Assert
 
 import scala.concurrent.duration.Duration
@@ -112,6 +114,20 @@ object StandardTestDBs {
     val profile = MySQLProfile
     // Recreating the DB is faster than dropping everything individually
     override def dropUserArtifacts(implicit session: profile.Backend#Session) = {
+      session.close()
+      cleanUpBefore()
+    }
+  }
+
+  lazy val Cassandra = new CassandraTestDB() {
+    val profile = CassandraProfile
+
+    val confName: String = "cassandra"
+
+    def createDB(): slick.cassandra.CassandraBackend#DatabaseDef =
+      profile.backend.Database.forConfig("testConn", config)
+
+    def dropUserArtifacts(implicit session: slick.cassandra.CassandraBackend#SessionDef): Unit = {
       session.close()
       cleanUpBefore()
     }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
@@ -18,6 +18,7 @@ import slick.SlickException
 import slick.basic.{BasicProfile, Capability}
 import slick.dbio.{NoStream, DBIOAction, DBIO}
 import slick.jdbc.{JdbcProfile, ResultSetAction, JdbcDataSource, SimpleJdbcAction}
+import slick.cassandra.CassandraProfile
 import slick.jdbc.GetResult._
 import slick.relational.RelationalProfile
 import slick.sql.SqlProfile
@@ -136,6 +137,10 @@ trait TestDB {
 
   /** The tests to run for this configuration. */
   def testClasses: Seq[Class[_ <: GenericTest[_ >: Null <: TestDB]]] = TestkitConfig.testClasses
+}
+
+trait CassandraTestDB extends TestDB {
+  type Profile = CassandraProfile
 }
 
 trait RelationalTestDB extends TestDB {

--- a/slick-testkit/src/test/scala/slick/test/profile/ProfileTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/profile/ProfileTest.scala
@@ -38,3 +38,6 @@ class MySQLTest extends ProfileTest(StandardTestDBs.MySQL)
 
 @RunWith(classOf[Testkit])
 class HeapTest extends ProfileTest(StandardTestDBs.Heap)
+
+@RunWith(classOf[Testkit])
+class CassandraTest extends ProfileTest(StandardTestDBs.Cassandra)

--- a/slick-testkit/src/test/scala/slick/test/unit/cassandra/TestCassandraDatabaseFactory.scala
+++ b/slick-testkit/src/test/scala/slick/test/unit/cassandra/TestCassandraDatabaseFactory.scala
@@ -1,0 +1,65 @@
+package test.scala.slick.test.unit.cassandra
+import org.scalatest._
+import org.scalamock.scalatest.MockFactory
+import slick.cassandra._
+import slick.SlickException
+import com.typesafe.config.{Config, ConfigFactory}
+
+class CassandraDatabaseFactoryTests extends WordSpec
+                                    with MockFactory
+                                    with CassandraBackend
+                                    with CassandraDatabaseFactory {
+
+  "A CassandraDatabaseFactory" when {
+    "given a config with a zookeeper address" should {
+      "return a zookeeper database" in {
+
+        val config = ConfigFactory.parseString("""
+          zookeeper = "127.0.0.1:2181"
+          zNode     = "/cassandra"
+          timeout   = 0
+          retryTime = 0
+          """)
+
+        val factory  = new DatabaseFactoryDef {}
+        val database = factory.forConfig("", config)
+
+        assert(database.isInstanceOf[ZookeeperDatabaseDef])
+      }
+    }
+
+    "given a config with direct cassandra nodes" should {
+      "return a direct database" in {
+
+        val config = ConfigFactory.parseString("""
+          nodes     = ["127.0.0.1:9042"]
+          timeout   = 0
+          retryTime = 0
+          """)
+
+        val factory  = new DatabaseFactoryDef {}
+        val database = factory.forConfig("", config)
+
+        assert(database.isInstanceOf[DirectDatabaseDef])
+      }
+    }
+
+    "given a config with both direct cassandra nodes and a zookeeper address" should {
+      "throw a SlickException" in {
+
+        val config = ConfigFactory.parseString("""
+          zookeeper = "127.0.0.1:2181"
+          nodes     = ["127.0.0.1:9042"]
+          timeout   = 0
+          retryTime = 0
+          """)
+
+        val factory  = new DatabaseFactoryDef {}
+
+        intercept[SlickException] {
+          val database = factory.forConfig("", config)
+        }
+      }
+    }
+  }
+}

--- a/slick-testkit/src/test/scala/slick/test/unit/cassandra/TestCassandraSessions.scala
+++ b/slick-testkit/src/test/scala/slick/test/unit/cassandra/TestCassandraSessions.scala
@@ -5,21 +5,53 @@ import org.scalatest.concurrent.AsyncAssertions.Waiter
 import time.SpanSugar._
 import org.scalamock.scalatest.MockFactory
 import slick.cassandra._
-import com.datastax.driver.core.{Cluster, Session, Configuration}
+import com.datastax.driver.core.{Cluster, Session, AbstractSession, Configuration}
 import com.datastax.driver.core.exceptions._
 import scala.util.{Success, Failure}
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.apache.curator.framework.state.ConnectionState
+import slick.SlickException
+import scala.concurrent.Await
 
-class CassandraDirectSessionTests extends WordSpec with MockFactory {
+class CassandraSessionTests extends WordSpec with MockFactory {
 
   class MockableCluster extends Cluster(null, null, null)
+
+  class MockSession extends Session {
+    var closeCalled = false
+
+    def close: Unit = {
+      closeCalled = true
+    }
+
+    def closeAsync(): com.datastax.driver.core.CloseFuture = ???
+    def execute(x$1: com.datastax.driver.core.Statement): com.datastax.driver.core.ResultSet = ???
+    def execute(x$1: String,x$2: Object*): com.datastax.driver.core.ResultSet = ???
+    def execute(x$1: String): com.datastax.driver.core.ResultSet = ???
+    def executeAsync(x$1: com.datastax.driver.core.Statement): com.datastax.driver.core.ResultSetFuture = ???
+    def executeAsync(x$1: String,x$2: Object*): com.datastax.driver.core.ResultSetFuture = ???
+    def executeAsync(x$1: String): com.datastax.driver.core.ResultSetFuture = ???
+    def getCluster(): com.datastax.driver.core.Cluster = ???
+    def getLoggedKeyspace(): String = ???
+    def getState(): com.datastax.driver.core.Session.State = ???
+    def init(): com.datastax.driver.core.Session = ???
+    def isClosed(): Boolean = ???
+    def newSimpleStatement(x$1: String,x$2: Object*): com.datastax.driver.core.SimpleStatement = ???
+    def newSimpleStatement(x$1: String): com.datastax.driver.core.SimpleStatement = ???
+    def prepare(x$1: com.datastax.driver.core.RegularStatement): com.datastax.driver.core.PreparedStatement = ???
+    def prepare(x$1: String): com.datastax.driver.core.PreparedStatement = ???
+    def prepareAsync(x$1: com.datastax.driver.core.RegularStatement): com.google.common.util.concurrent.ListenableFuture[com.datastax.driver.core.PreparedStatement] = ???
+    def prepareAsync(x$1: String): com.google.common.util.concurrent.ListenableFuture[com.datastax.driver.core.PreparedStatement] = ???
+  }
 
   class MockClusterBuilder extends Cluster.Builder {
     var hasContactPoints = false
     var shouldThrowNoHostAvailable = false
     override def addContactPoint(ip: String): Cluster.Builder = {
-      if (ip == "500.0.0.2") {
+      if (ip startsWith "500") {
         throw new IllegalArgumentException
+      } else if (ip startsWith "400") {
+        throw new SlickException("")
       } else if (ip == "127.0.0.2") {
         shouldThrowNoHostAvailable = true
         this
@@ -42,11 +74,52 @@ class CassandraDirectSessionTests extends WordSpec with MockFactory {
       if (shouldThrowNoHostAvailable) {
         val map = new java.util.HashMap[java.net.InetSocketAddress, Throwable]()
         (cluster.connect _) when() throws new NoHostAvailableException(map)
+      } else {
+        (cluster.connect _) when() returns new MockSession
       }
 
       cluster
     }
   }
+
+  import org.apache.curator.framework.{CuratorFrameworkFactory, CuratorFramework}
+  import org.apache.curator.framework.recipes.cache.{NodeCache, NodeCacheListener}
+  import org.apache.curator.RetryPolicy
+
+  val mockFramework = stub[CuratorFramework]
+
+  def mockNewClient(zookeeperLocation: String, retryPolicy: RetryPolicy): CuratorFramework = {
+    import org.apache.curator.framework.listen.ListenerContainer
+    import org.apache.curator.framework.state.ConnectionStateListener
+
+    val connectionStateListenable = new ListenerContainer[ConnectionStateListener]
+    (mockFramework.getConnectionStateListenable _) when() returns(connectionStateListenable)
+
+    mockFramework
+  }
+
+  class MockNodeCache extends NodeCache(null, "/") {
+    import org.apache.curator.framework.listen.{ListenerContainer, Listenable}
+    import org.apache.curator.framework.recipes.cache.ChildData
+    import org.apache.zookeeper.data.Stat
+
+    override def getListenable: ListenerContainer[NodeCacheListener] = new ListenerContainer[NodeCacheListener]
+    override def start: Unit = {}
+    override def close: Unit = {}
+
+    override def getCurrentData: ChildData = new ChildData("/cassandra", new Stat, "127.0.0.1:9042".getBytes)
+  }
+
+  class InvalidMockNodeCache extends MockNodeCache {
+    import org.apache.curator.framework.recipes.cache.ChildData
+    import org.apache.zookeeper.data.Stat
+
+    override def getCurrentData: ChildData = new ChildData("/cassandra", new Stat, "400.0.0.1:9042".getBytes)
+  }
+
+  def mockNodeCache = (zk: CuratorFramework, zNode: String) => new MockNodeCache
+
+  def invalidMockNodeCache = (zk: CuratorFramework, zNode: String) => new InvalidMockNodeCache
 
   "A DirectSession" when {
     "given a valid node" should {
@@ -60,50 +133,176 @@ class CassandraDirectSessionTests extends WordSpec with MockFactory {
     }
 
     "given an invalid node" should {
-      "fail the connection future with IllegalArgumentException" in {
+      "throw an IllegalArgumentException" in {
         val builder = new MockClusterBuilder
 
-        val session = new DirectSession(List("500.0.0.2:9042"), builder)
-        val w = new Waiter
-        session.connection onComplete {
-          case Failure(e) => w(throw e); w.dismiss()
-          case Success(_) => w.dismiss()
-        }
         intercept[IllegalArgumentException] {
-          w.await
+          val session = new DirectSession(List("500.0.0.2:9042"), builder)
         }
       }
     }
 
     "given an unreachable node" should {
-      "fail the connection future with NoHostAvailableException" in {
+      "throw an NoHostAvailableException" in {
         val builder = new MockClusterBuilder
 
-        val session = new DirectSession(List("127.0.0.2:9042"), builder)
-        val w = new Waiter
-        session.connection onComplete {
-          case Failure(e) => w(throw e); w.dismiss()
-          case Success(_) => w.dismiss()
-        }
         intercept[NoHostAvailableException] {
-          w.await
+          val session = new DirectSession(List("127.0.0.2:9042"), builder)
         }
       }
     }
 
     "given an empty list" should {
-      "fail the connection future with NoHostAvailableException" in {
+      "throw an NoHostAvailableException" in {
         val builder = new MockClusterBuilder
 
-        val session = new DirectSession(List(), builder)
+        intercept[NoHostAvailableException] {
+          val session = new DirectSession(List(), builder)
+        }
+      }
+    }
+  }
+
+  "a ZookeeperSession" when {
+    "given a valid zookeeper address with a valid cassandra zNode" should {
+      "return a successful future" in {
+        val builder  = new MockClusterBuilder
+
+        val session = new ZookeeperSession("127.0.0.1:2181", "/cassandra", 10, 1, builder, mockNewClient, mockNodeCache)
+        session.stateChanged(mockFramework, ConnectionState.CONNECTED)
+        session.nodeChanged()
+        assert(session.connection.isReadyWithin(100 millis))
+      }
+    }
+
+    "given an invalid zookeeper address" should {
+      "throw a SlickException" in {
+        val builder  = new MockClusterBuilder
+
+        intercept[SlickException] {
+          val session = new ZookeeperSession("500.0.0.1:2181", "/cassandra", 10, 1, builder, mockNewClient, mockNodeCache)
+        }
+      }
+    }
+
+    "given an unreachable zookeeper address" should {
+      "fail the connection future with SlickException" in {
+        val builder = new MockClusterBuilder
+
+        val session = new ZookeeperSession("192.168.0.1:2181", "/cassandra", 10, 1, builder, mockNewClient, mockNodeCache)
         val w = new Waiter
         session.connection onComplete {
           case Failure(e) => w(throw e); w.dismiss()
           case Success(_) => w.dismiss()
         }
-        intercept[NoHostAvailableException] {
+        intercept[SlickException] {
           w.await
         }
+      }
+    }
+
+    "given an invalid zNode path" should {
+      "fail the connection future with SlickException" in {
+        val builder = new MockClusterBuilder
+
+        val session = new ZookeeperSession("127.0.0.1:2181", "/cassondry", 10, 1, builder, mockNewClient, mockNodeCache)
+        session.stateChanged(mockFramework, ConnectionState.CONNECTED)
+        val w = new Waiter
+        session.connection onComplete {
+          case Failure(e) => w(throw e); w.dismiss()
+          case Success(_) => w.dismiss()
+        }
+        intercept[SlickException] {
+          w.await
+        }
+      }
+    }
+
+    "given a valid zNode path with an invalid cassandra address" should {
+      "fail the connection future with SlickException" in {
+        val builder = new MockClusterBuilder
+
+        val session = new ZookeeperSession("127.0.0.1:2181", "/cassandra", 10, 1, builder, mockNewClient, invalidMockNodeCache)
+        session.stateChanged(mockFramework, ConnectionState.CONNECTED)
+        session.nodeChanged()
+        val w = new Waiter
+        session.connection onComplete {
+          case Failure(e) => w(throw e); w.dismiss()
+          case Success(_) => w.dismiss()
+        }
+        intercept[SlickException] {
+          w.await
+        }
+      }
+    }
+
+    "given a valid zNode that is later changed after making a good connection" should {
+      "throw a SlickException" in {
+        val builder = new MockClusterBuilder
+
+        val session = new ZookeeperSession("127.0.0.1:2181", "/cassandra", 10, 1, builder, mockNewClient, mockNodeCache)
+        session.stateChanged(mockFramework, ConnectionState.CONNECTED)
+        session.nodeChanged()
+        intercept[SlickException] {
+          session.nodeChanged()
+        }
+      }
+    }
+
+    "given a valid configuration but a slow link to zookeeper" should {
+      "fail the connection future with a SlickException" in {
+        val builder = new MockClusterBuilder
+
+        val session = new ZookeeperSession("127.0.0.1:2181", "/cassandra", 10, 1, builder, mockNewClient, mockNodeCache)
+        val w = new Waiter
+        session.connection onComplete {
+          case Failure(e) => w(throw e); w.dismiss()
+          case Success(_) => w.dismiss()
+        }
+        intercept[SlickException] {
+          w.await
+        }
+      }
+    }
+
+    "given a valid configuration, a good link to zookeeper, but a slow link to cassandra" should {
+      "fail the connection future with a SlickException" in {
+        val builder = new MockClusterBuilder
+
+        val session = new ZookeeperSession("127.0.0.1:2181", "/cassandra", 10, 1, builder, mockNewClient, mockNodeCache)
+        session.stateChanged(mockFramework, ConnectionState.CONNECTED)
+        val w = new Waiter
+        session.connection onComplete {
+          case Failure(e) => w(throw e); w.dismiss()
+          case Success(_) => w.dismiss()
+        }
+        intercept[SlickException] {
+          w.await
+        }
+      }
+    }
+
+    "closing the slick session" should {
+      "close a completed cassandra connection" in {
+        val builder = new MockClusterBuilder
+
+        val session = new ZookeeperSession("127.0.0.1:2181", "/cassandra", 10, 1, builder, mockNewClient, mockNodeCache)
+        session.stateChanged(mockFramework, ConnectionState.CONNECTED)
+        session.nodeChanged()
+        session.close()
+        assert(Await.result(session.connection, 0 millis).asInstanceOf[MockSession].closeCalled)
+      }
+
+      "close the zookeeper connection" in {
+        val builder = new MockClusterBuilder
+
+        val session = new ZookeeperSession("127.0.0.1:2181", "/cassandra", 10, 1, builder, mockNewClient, mockNodeCache)
+        session.stateChanged(mockFramework, ConnectionState.CONNECTED)
+        session.nodeChanged()
+        session.close()
+        var closed = false
+        (mockFramework.close _) when() returns({closed = true})
+        assert(closed)
       }
     }
   }

--- a/slick-testkit/src/test/scala/slick/test/unit/cassandra/TestCassandraSessions.scala
+++ b/slick-testkit/src/test/scala/slick/test/unit/cassandra/TestCassandraSessions.scala
@@ -1,0 +1,110 @@
+package test.scala.slick.test.unit.cassandra
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures._
+import org.scalatest.concurrent.AsyncAssertions.Waiter
+import time.SpanSugar._
+import org.scalamock.scalatest.MockFactory
+import slick.cassandra._
+import com.datastax.driver.core.{Cluster, Session, Configuration}
+import com.datastax.driver.core.exceptions._
+import scala.util.{Success, Failure}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class CassandraDirectSessionTests extends WordSpec with MockFactory {
+
+  class MockableCluster extends Cluster(null, null, null)
+
+  class MockClusterBuilder extends Cluster.Builder {
+    var hasContactPoints = false
+    var shouldThrowNoHostAvailable = false
+    override def addContactPoint(ip: String): Cluster.Builder = {
+      if (ip == "500.0.0.2") {
+        throw new IllegalArgumentException
+      } else if (ip == "127.0.0.2") {
+        shouldThrowNoHostAvailable = true
+        this
+      } else {
+        hasContactPoints = true
+        this
+      }
+    }
+
+    override def withPort(port: Int): Cluster.Builder = {
+      this
+    }
+
+    override def build: Cluster = {
+      val cluster = stub[MockableCluster]
+      if (!hasContactPoints) {
+        shouldThrowNoHostAvailable = true
+      }
+
+      if (shouldThrowNoHostAvailable) {
+        val map = new java.util.HashMap[java.net.InetSocketAddress, Throwable]()
+        (cluster.connect _) when() throws new NoHostAvailableException(map)
+      }
+
+      cluster
+    }
+  }
+
+  "A DirectSession" when {
+    "given a valid node" should {
+      "return a successful future" in {
+        val builder  = new MockClusterBuilder
+
+        val session = new DirectSession(List("127.0.0.1:9042"), builder)
+        assert(session.connection.isReadyWithin(100 millis))
+      }
+
+    }
+
+    "given an invalid node" should {
+      "fail the connection future with IllegalArgumentException" in {
+        val builder = new MockClusterBuilder
+
+        val session = new DirectSession(List("500.0.0.2:9042"), builder)
+        val w = new Waiter
+        session.connection onComplete {
+          case Failure(e) => w(throw e); w.dismiss()
+          case Success(_) => w.dismiss()
+        }
+        intercept[IllegalArgumentException] {
+          w.await
+        }
+      }
+    }
+
+    "given an unreachable node" should {
+      "fail the connection future with NoHostAvailableException" in {
+        val builder = new MockClusterBuilder
+
+        val session = new DirectSession(List("127.0.0.2:9042"), builder)
+        val w = new Waiter
+        session.connection onComplete {
+          case Failure(e) => w(throw e); w.dismiss()
+          case Success(_) => w.dismiss()
+        }
+        intercept[NoHostAvailableException] {
+          w.await
+        }
+      }
+    }
+
+    "given an empty list" should {
+      "fail the connection future with NoHostAvailableException" in {
+        val builder = new MockClusterBuilder
+
+        val session = new DirectSession(List(), builder)
+        val w = new Waiter
+        session.connection onComplete {
+          case Failure(e) => w(throw e); w.dismiss()
+          case Success(_) => w.dismiss()
+        }
+        intercept[NoHostAvailableException] {
+          w.await
+        }
+      }
+    }
+  }
+}

--- a/slick/src/main/scala/slick/cassandra/CassandraActionComponent.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraActionComponent.scala
@@ -1,0 +1,89 @@
+package slick.cassandra
+import slick.sql.{SqlActionComponent, FixedSqlAction, FixedSqlStreamingAction}
+import slick.ast.Node
+import slick.dbio.{NoStream, DBIOAction, Effect, SynchronousDatabaseAction}
+import slick.SlickException
+
+trait CassandraActionComponent extends SqlActionComponent { self: CassandraProfile =>
+  type ProfileAction[+R, +S <: NoStream, -E <: Effect] = FixedSqlAction[R, S, E]
+  type StreamingProfileAction[+R, +T, -E <: Effect] = FixedSqlStreamingAction[R, T, E]
+
+  type QueryActionExtensionMethods[R, S <: NoStream] = QueryActionExtensionMethodsImpl[R, S]
+  type StreamingQueryActionExtensionMethods[R, T] = StreamingQueryActionExtensionMethodsImpl[R, T]
+
+  class StubAction[+R, +S <: NoStream, -E <: Effect] extends ProfileAction[R, S, E] {
+    def overrideStatements(statements: Iterable[String]): slick.sql.SqlAction[R,S,E] = ???
+    def statements: Iterable[String] = ???
+  }
+
+  abstract class CassandraAction[+R](_name: String, val statements: Vector[String]) extends SynchronousDatabaseAction[R, NoStream, Backend, Effect] with ProfileAction[R, NoStream, Effect] { self =>
+    def run(ctx: Backend#Context, sql: Vector[String]): R
+    final override def getDumpInfo = super.getDumpInfo.copy(name = _name)
+    final def run(ctx: Backend#Context): R = run(ctx, statements)
+    final def overrideStatements(_statements: Iterable[String]): ProfileAction[R, NoStream, Effect] = new CassandraAction[R](_name, _statements.toVector) {
+      def run(ctx: Backend#Context, sql: Vector[String]): R = self.run(ctx, statements)
+    }
+  }
+
+  class StreamingStubAction[+R, +S, -E <: Effect] extends StreamingProfileAction[R, S, E] {
+    def overrideStatements(statements: Iterable[String]): slick.sql.SqlAction[R,slick.dbio.Streaming[S],E] = ???
+    def statements: Iterable[String] = ???
+    def head: slick.sql.SqlAction[S,slick.dbio.NoStream,E] = ???
+    def headOption: slick.sql.SqlAction[Option[S],slick.dbio.NoStream,E] = ???
+  }
+
+  def createQueryActionExtensionMethods[R, S <: NoStream](tree: Node,param: Any): QueryActionExtensionMethods[R,S] =
+    new QueryActionExtensionMethodsImpl[R, S](tree, param)
+
+  class QueryActionExtensionMethodsImpl[R, S <: NoStream](tree: Node, param: Any) extends super.QueryActionExtensionMethodsImpl[R, S] {
+    def result: ProfileAction[R, S, Effect.Read] =
+      new StubAction[R, S, Effect.Read]
+  }
+
+  def createStreamingQueryActionExtensionMethods[R, T](tree: Node,param: Any): StreamingQueryActionExtensionMethods[R,T] =
+    new StreamingQueryActionExtensionMethodsImpl[R, T](tree, param)
+
+  class StreamingQueryActionExtensionMethodsImpl[R, T](tree: Node, param: Any) extends super.StreamingQueryActionExtensionMethodsImpl[R, T] {
+    def result: StreamingProfileAction[R, T, Effect.Read] =
+      new StreamingStubAction[R, T, Effect]
+  }
+
+  type InsertActionExtensionMethods[T] = CreateInsertActionExtensionMethodsImpl[T]
+
+  def createInsertActionExtensionMethods[T](compiled: CompiledInsert): InsertActionExtensionMethods[T] =
+    new CreateInsertActionExtensionMethodsImpl[T](compiled)
+
+  class CreateInsertActionExtensionMethodsImpl[T](compiled: CompiledInsert) extends super.InsertActionExtensionMethodsImpl[T] {
+    /** The result type when inserting a single value. */
+    type SingleInsertResult = Int
+
+    /** The result type when inserting a collection of values. */
+    type MultiInsertResult = Int
+
+    /** An Action that inserts a single value. */
+    def += (value: T): ProfileAction[SingleInsertResult, NoStream, Effect.Write] =
+      new StubAction[SingleInsertResult, NoStream, Effect.Write]
+
+    /** An Action that inserts a collection of values. */
+    def ++= (values: Iterable[T]): ProfileAction[MultiInsertResult, NoStream, Effect.Write] =
+      new StubAction[MultiInsertResult, NoStream, Effect.Write]
+  }
+
+  type SchemaActionExtensionMethods = SchemaActionExtensionMethodsImpl
+
+  def createSchemaActionExtensionMethods(schema: SchemaDescription): SchemaActionExtensionMethods =
+    new SchemaActionExtensionMethodsImpl(schema)
+
+  class SchemaActionExtensionMethodsImpl(schema: SchemaDescription) extends super.SchemaActionExtensionMethodsImpl {
+    /** Create an Action that creates the entities described by this schema description. */
+    def create: ProfileAction[Unit, NoStream, Effect.Schema] = new CassandraAction[Unit]("schema.create", schema.createStatements.toVector) {
+      def run(ctx: Backend#Context, sql: Vector[String]): Unit = {
+        println("Create statements:")
+        sql foreach println
+      }
+    }
+
+    /** Create an Action that drops the entities described by this schema description. */
+    def drop: ProfileAction[Unit, NoStream, Effect.Schema] = new StubAction[Unit, NoStream, Effect]
+  }
+}

--- a/slick/src/main/scala/slick/cassandra/CassandraActionComponent.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraActionComponent.scala
@@ -78,8 +78,6 @@ trait CassandraActionComponent extends SqlActionComponent { self: CassandraProfi
     /** Create an Action that creates the entities described by this schema description. */
     def create: ProfileAction[Unit, NoStream, Effect.Schema] = new CassandraAction[Unit]("schema.create", schema.createStatements.toVector) {
       def run(ctx: Backend#Context, sql: Vector[String]): Unit = {
-        println("Create statements:")
-        sql foreach println
       }
     }
 

--- a/slick/src/main/scala/slick/cassandra/CassandraBackend.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraBackend.scala
@@ -122,24 +122,17 @@ trait CassandraBackend extends RelationalBackend {
     import com.typesafe.config.ConfigFactory
     import scala.collection.convert.wrapAll._
 
-    val defaults: Config = ConfigFactory.parseMap(Map(
-      "zookeeper"          -> "127.0.0.1",
-      "zNode"              -> "/cassandra",
-      "timeout"   -> 60000,
-      "retryTime" -> 5000))
-
     def forConfig(path: String, config: Config): Database = {
       val usedConfig = if (path.isEmpty) config else config.getConfig(path)
-      val fallbackConfig = usedConfig withFallback defaults
-      val timeout = fallbackConfig.getInt("timeout")
-      val retryTime = fallbackConfig.getInt("retryTime")
+      val timeout = usedConfig.getInt("timeout")
+      val retryTime = usedConfig.getInt("retryTime")
 
-      if (fallbackConfig.hasPath("nodes")) {
-        val nodes = fallbackConfig.getStringList("nodes").toList
+      if (usedConfig.hasPath("nodes")) {
+        val nodes = usedConfig.getStringList("nodes").toList
         new DirectDatabaseDef(AsyncExecutor.default(), nodes, timeout, retryTime)
       } else {
-        val zookeeperLocation = fallbackConfig.getString("zookeeper")
-        val zNode = fallbackConfig.getString("zNode")
+        val zookeeperLocation = usedConfig.getString("zookeeper")
+        val zNode = usedConfig.getString("zNode")
         new ZookeeperDatabaseDef(AsyncExecutor.default(), zookeeperLocation, zNode, timeout, retryTime)
       }
     }

--- a/slick/src/main/scala/slick/cassandra/CassandraBackend.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraBackend.scala
@@ -88,10 +88,8 @@ trait CassandraBackend extends RelationalBackend
     extends ZookeeperSession(zookeeperLocation, zNode, timeout, retryTime)
     with SessionDef
 
-  class DirectSessionDef (override val nodes: List[String],
-                          override val timeout: Int,
-                          override val retryTime: Int)
-    extends    DirectSession(nodes, timeout, retryTime)
+  class DirectSessionDef (override val nodes: List[String])
+    extends    DirectSession(nodes)
     with SessionDef
 
   /** The context object passed to database actions by the execution engine. */

--- a/slick/src/main/scala/slick/cassandra/CassandraBackend.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraBackend.scala
@@ -44,8 +44,8 @@ trait CassandraBackend extends RelationalBackend {
     *                     of the cassandra nodes.  Must specify either 'nodes'
     *                     or 'zookeeper', but not both.  Default is to use
     *                     zookeeper.
-    * zookeeper:          IPv4 address pointing to zookeeper instance with
-    *                     cassandra config.  Defaults to '127.0.0.1'
+    * zookeeper:          IPv4 address:port pointing to zookeeper instance with
+    *                     cassandra config.  Defaults to '127.0.0.1:2181'
     * zNode:              zNode containing location of cassandra nodes in
     *                     zookeeper. defaults to '/cassandra'
     * timeout:            milliseconds to wait for connection before aborting.

--- a/slick/src/main/scala/slick/cassandra/CassandraBackend.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraBackend.scala
@@ -1,0 +1,141 @@
+package slick.cassandra
+import slick.relational.RelationalBackend
+
+import scala.language.existentials
+
+import java.io.Closeable
+import java.util.concurrent.atomic.{AtomicReferenceArray, AtomicBoolean, AtomicLong}
+
+import com.typesafe.config.Config
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.{Promise, ExecutionContext, Future, Await}
+import scala.concurrent.duration._
+import scala.util.{Try, Success, Failure}
+import scala.util.control.NonFatal
+
+import org.slf4j.LoggerFactory
+import org.reactivestreams._
+
+import slick.SlickException
+import slick.dbio._
+import slick.util._
+
+/** Backend for the basic database and session handling features.
+  * Concrete backends like `JdbcBackend` extend this type and provide concrete
+  * types for `Database`, `DatabaseFactory` and `Session`. */
+trait CassandraBackend extends RelationalBackend {
+
+  type This = CassandraBackend
+  type Database = DatabaseDef
+  type DatabaseFactory = DatabaseFactoryDef
+  type Context = CassandraActionContext
+  type StreamingContext = CassandraStreamingActionContext
+
+  // This is a session in the Slick sense, not in the Cassandra/Datastax sense.
+  type Session = SessionDef
+  // For convenience working inside this file.
+  type CassandraSession = com.datastax.driver.core.Session
+
+  val Database: DatabaseFactory = new DatabaseFactoryDef {}
+  val backend: CassandraBackend = this
+
+  /** Create a Database instance through [[https://github.com/typesafehub/config Typesafe Config]].
+    * The supported config keys are backend-specific. This method is used by `DatabaseConfig`.
+    * @param path The path in the configuration file for the database configuration, or an empty
+    *             string for the top level of the `Config` object.
+    * @param config The `Config` object to read from.
+    */
+  def createDatabase(config: Config, path: String): Database = Database.forConfig(path, config)
+
+  /** A database instance to which connections can be created. */
+  class DatabaseDef(val executor: AsyncExecutor, val zookeeperLocation: String) extends super.DatabaseDef { this: Database =>
+    /** Create a new session. The session needs to be closed explicitly by calling its close() method. */
+    def createSession(): Session = {
+      new SessionDef(zookeeperLocation)
+    }
+
+    /** Free all resources allocated by Slick for this Database, blocking the current thread until
+      * everything has been shut down.
+      *
+      * Backend implementations which are based on a naturally blocking shutdown procedure can
+      * simply implement this method and get `shutdown` as an asynchronous wrapper for free. If
+      * the underlying shutdown procedure is asynchronous, you should implement `shutdown` instead
+      * and wrap it with `Await.result` in this method. */
+    def close: Unit = {
+    }
+
+    /** Create the default DatabaseActionContext for this backend. */
+    protected[this] def createDatabaseActionContext[T](_useSameThread: Boolean): Context =
+      new CassandraActionContext { val useSameThread = _useSameThread }
+
+    /** Create the default StreamingDatabaseActionContext for this backend. */
+    protected[this] def createStreamingDatabaseActionContext[T](s: Subscriber[_ >: T], useSameThread: Boolean): StreamingContext =
+      new CassandraStreamingActionContext(s, useSameThread, this)
+
+    /** Return the default ExecutionContext for this Database which should be used for running
+      * SynchronousDatabaseActions for asynchronous execution. */
+    protected[this] def synchronousExecutionContext: ExecutionContext = executor.executionContext
+  }
+
+  trait DatabaseFactoryDef {
+    def forConfig(path: String, config: Config): Database = {
+      val usedConfig = if (path.isEmpty) config else config.getConfig(path)
+      val zookeeperLocation = config.getString("zookeeper")
+      new DatabaseDef(AsyncExecutor.default(), zookeeperLocation)
+    }
+  }
+
+  import org.apache.curator.framework.recipes.cache.{NodeCache, NodeCacheListener}
+
+  class SessionDef(val zookeeperLocation: String) extends super.SessionDef  with NodeCacheListener {
+    import org.apache.curator.framework.CuratorFrameworkFactory
+    import org.apache.curator.retry.RetryForever
+    import com.datastax.driver.core.Cluster
+
+    val zk = CuratorFrameworkFactory.newClient(zookeeperLocation, new RetryForever(5000))
+    zk.start()
+
+    val nodeCache = new NodeCache(zk, "/cassandra")
+    nodeCache.getListenable().addListener(this)
+    nodeCache.start()
+    val connectionPromise = Promise[CassandraSession]
+    val connection = connectionPromise.future
+
+    def nodeChanged: Unit = {
+      def addNodes(builder: Cluster.Builder, nodes: Iterator[String]): Cluster.Builder = {
+        if (nodes.hasNext) {
+          val Array(ip, port) = nodes.next().split(':')
+          addNodes(builder.addContactPoint(ip), nodes)
+        } else {
+          builder
+        }
+      }
+
+      val data = new String(nodeCache.getCurrentData.getData)
+      val nodes = data.lines
+      val cluster = addNodes(Cluster.builder, nodes).build
+      connectionPromise success cluster.connect
+    }
+
+    def close(): Unit = {
+      if (connection.isCompleted)
+        Await.result(connection, Duration.Zero).close()
+      nodeCache.close()
+      zk.close()
+    }
+
+    def force(): Unit = {
+    }
+  }
+
+  /** The context object passed to database actions by the execution engine. */
+  trait CassandraActionContext extends BasicActionContext {
+    def connection: CassandraSession = Await.result(session.connection, Duration(1, MINUTES))
+  }
+
+  /** A special DatabaseActionContext for streaming execution. */
+  class CassandraStreamingActionContext(subscriber: Subscriber[_], useSameThread: Boolean, database: Database) extends BasicStreamingActionContext(subscriber, useSameThread, database) with CassandraActionContext
+}
+
+object CassandraBackend extends CassandraBackend

--- a/slick/src/main/scala/slick/cassandra/CassandraBackend.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraBackend.scala
@@ -42,8 +42,7 @@ trait CassandraBackend extends RelationalBackend
     * Supported config keys:
     * nodes:              Array of "IPv4 address:port" containing the location
     *                     of the cassandra nodes.  Must specify either 'nodes'
-    *                     or 'zookeeper', but not both.  Default is to use
-    *                     zookeeper.
+    *                     or 'zookeeper', but not both.
     * zookeeper:          IPv4 address:port pointing to zookeeper instance with
     *                     cassandra config.  Defaults to '127.0.0.1:2181'
     * zNode:              zNode containing location of cassandra nodes in

--- a/slick/src/main/scala/slick/cassandra/CassandraDatabaseFactory.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraDatabaseFactory.scala
@@ -1,0 +1,25 @@
+package slick.cassandra
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import scala.collection.convert.wrapAll._
+import slick.util.AsyncExecutor
+
+trait CassandraDatabaseFactory {self: CassandraBackend =>
+  trait DatabaseFactoryDef {
+
+    def forConfig(path: String, config: Config): self.DatabaseDef = {
+      val usedConfig = if (path.isEmpty) config else config.getConfig(path)
+      val timeout = usedConfig.getInt("timeout")
+      val retryTime = usedConfig.getInt("retryTime")
+
+      if (usedConfig.hasPath("nodes")) {
+        val nodes = usedConfig.getStringList("nodes").toList
+        new self.DirectDatabaseDef(AsyncExecutor.default(), nodes, timeout, retryTime)
+      } else {
+        val zookeeperLocation = usedConfig.getString("zookeeper")
+        val zNode = usedConfig.getString("zNode")
+        new self.ZookeeperDatabaseDef(AsyncExecutor.default(), zookeeperLocation, zNode, timeout, retryTime)
+      }
+    }
+  }
+}

--- a/slick/src/main/scala/slick/cassandra/CassandraDatabaseFactory.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraDatabaseFactory.scala
@@ -3,6 +3,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import scala.collection.convert.wrapAll._
 import slick.util.AsyncExecutor
+import slick.SlickException
 
 trait CassandraDatabaseFactory {self: CassandraBackend =>
   trait DatabaseFactoryDef {
@@ -11,6 +12,9 @@ trait CassandraDatabaseFactory {self: CassandraBackend =>
       val usedConfig = if (path.isEmpty) config else config.getConfig(path)
       val timeout = usedConfig.getInt("timeout")
       val retryTime = usedConfig.getInt("retryTime")
+
+      if (usedConfig.hasPath("nodes") && usedConfig.hasPath("zookeeper"))
+        throw new SlickException("Config cannot contain both zookeeper node and direct cassandra entries.")
 
       if (usedConfig.hasPath("nodes")) {
         val nodes = usedConfig.getStringList("nodes").toList

--- a/slick/src/main/scala/slick/cassandra/CassandraDatabases.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraDatabases.scala
@@ -1,0 +1,51 @@
+package slick.cassandra
+
+import slick.util.AsyncExecutor
+import scala.concurrent.ExecutionContext
+import org.reactivestreams.Subscriber
+
+trait CassandraDatabases {self: CassandraBackend =>
+
+  abstract class CassandraDatabase(val executor: AsyncExecutor) {
+    /** Create the default DatabaseActionContext for this backend. */
+    protected[this] def createDatabaseActionContext[T](_useSameThread: Boolean): self.Context =
+      new CassandraActionContext { val useSameThread = _useSameThread }
+
+    /** Return the default ExecutionContext for this Database which should be used for running
+      * SynchronousDatabaseActions for asynchronous execution. */
+    protected[this] def synchronousExecutionContext: ExecutionContext = executor.executionContext
+  }
+
+  /** A database instance to which connections can be created, which uses
+    * zookeeper to keep track of the cassandra nodes. */
+  class ZookeeperDatabase(override val executor: AsyncExecutor,
+    val zookeeperLocation: String,
+    val zNode: String,
+    val timeout: Int,
+    val retryTime: Int) extends CassandraDatabase(executor) {
+
+    /** Create a new session. The session needs to be closed explicitly by calling its close() method. */
+    def createSession(): Session = {
+      new ZookeeperSessionDef(zookeeperLocation, zNode, timeout, retryTime)
+    }
+
+    def close: Unit = {
+    }
+  }
+
+  /** A database instance to which connections can be created, which takes a
+    * list of cassandra nodes directly. */
+  class DirectDatabase(override val executor: AsyncExecutor,
+    val nodes: List[String],
+    val timeout: Int,
+    val retryTime: Int) extends CassandraDatabase(executor) {
+
+    /** Create a new session. The session needs to be closed explicitly by calling its close() method. */
+    def createSession(): Session = {
+      new DirectSessionDef(nodes, timeout, retryTime)
+    }
+
+    def close: Unit = {
+    }
+  }
+}

--- a/slick/src/main/scala/slick/cassandra/CassandraDatabases.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraDatabases.scala
@@ -42,7 +42,7 @@ trait CassandraDatabases {self: CassandraBackend =>
 
     /** Create a new session. The session needs to be closed explicitly by calling its close() method. */
     def createSession(): Session = {
-      new DirectSessionDef(nodes, timeout, retryTime)
+      new DirectSessionDef(nodes)
     }
 
     def close: Unit = {

--- a/slick/src/main/scala/slick/cassandra/CassandraProfile.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraProfile.scala
@@ -1,0 +1,81 @@
+package slick.cassandra
+import slick.basic._
+import slick.sql._
+
+import scala.language.{higherKinds, implicitConversions, existentials}
+
+import slick.SlickException
+import slick.ast._
+import slick.compiler.QueryCompiler
+import slick.dbio._
+import slick.lifted._
+import slick.util.{GlobalConfig, DumpInfo}
+
+import com.typesafe.config.{ConfigFactory, Config}
+
+trait CassandraProfile extends SqlProfile with CassandraActionComponent
+  with CassandraTypesComponent {
+
+  type Backend = CassandraBackend
+  val backend: Backend = CassandraBackend
+
+  type ColumnType[T] = CassandraType[T]
+  type BaseColumnType[T] = CassandraType[T] with BaseTypedType[T]
+
+  override protected def computeCapabilities: Set[Capability] = Set.empty
+
+  val api: API = new API {}
+
+  lazy val queryCompiler  = compiler
+  lazy val updateCompiler = compiler
+  lazy val deleteCompiler = compiler
+  lazy val insertCompiler = compiler
+
+  type CompiledInsert = CassandraCompiledInsert
+  def compileInsert(n: Node): CompiledInsert = new CassandraCompiledInsert()
+  class CassandraCompiledInsert {}
+
+  def runSynchronousQuery[R](tree: Node,param: Any)(implicit session: Backend#Session): R = ???
+
+  def buildSequenceSchemaDescription(seq: Sequence[_]): SchemaDescription = new SequenceDDL
+
+  def buildTableSchemaDescription(table: Table[_]): SchemaDescription = new TableDDL(table)
+
+  lazy val MappedColumnType: MappedColumnTypeFactory = MappedCassandraType
+
+  case class SimpleCassandraAction[+R](f: CassandraBackend#Context => R) extends SynchronousDatabaseAction[R, NoStream, CassandraBackend, Effect.All] {
+    def run(context: CassandraBackend#Context): R = f(context)
+    def getDumpInfo = DumpInfo(name = "SimpleCassandraAction")
+  }
+
+  trait API extends super.API with ImplicitColumnTypes {
+    type SimpleDBIO[+R] = SimpleCassandraAction[R]
+    val SimpleDBIO = SimpleCassandraAction
+  }
+
+  class SequenceDDL extends super.DDL {
+    def createPhase1: Iterable[String] = ???
+    def createPhase2: Iterable[String] = ???
+    def dropPhase1: Iterable[String] = ???
+    def dropPhase2: Iterable[String] = ???
+  }
+
+  class TableDDL(val table: Table[_]) extends super.DDL {
+    val columns: Iterable[FieldSymbol] = table.create_*
+    val tableNode = table.tableNode
+
+    def createPhase1: Iterable[String] = {
+      val name = quoteTableName(tableNode)
+      val columns = "test int PRIMARY KEY"
+      val cql = "CREATE TABLE " + name + "(" + columns + ");"
+      println(cql)
+      Iterable(cql)
+    }
+    def createPhase2: Iterable[String] = Iterable()
+    def dropPhase1: Iterable[String] = ???
+    def dropPhase2: Iterable[String] = ???
+  }
+}
+
+object CassandraProfile extends CassandraProfile {
+}

--- a/slick/src/main/scala/slick/cassandra/CassandraSessions.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraSessions.scala
@@ -17,7 +17,7 @@ abstract class CassandraSessionDef {
     def addNodes(builder: Cluster.Builder, nodes: Iterator[String]): Cluster.Builder = {
       if (nodes.hasNext) {
         val Array(ip, port) = nodes.next().split(':')
-        addNodes(builder.addContactPoint(ip), nodes)
+        addNodes(builder.addContactPoint(ip).withPort(port.toInt), nodes)
       } else {
         builder
       }

--- a/slick/src/main/scala/slick/cassandra/CassandraSessions.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraSessions.scala
@@ -1,0 +1,105 @@
+package slick.cassandra
+import org.apache.curator.framework.recipes.cache.{NodeCache, NodeCacheListener}
+import org.apache.curator.framework.state.ConnectionStateListener
+import scala.concurrent.{Promise, ExecutionContext, Future, Await}
+import com.datastax.driver.core.Session
+import slick.SlickException
+import scala.concurrent.duration._
+
+abstract class CassandraSessionDef {
+  import com.datastax.driver.core.Cluster
+
+  val connection: Future[Session]
+  def close(): Unit
+  def force(): Unit
+
+  def buildCluster(nodes: Iterator[String]): Cluster = {
+    def addNodes(builder: Cluster.Builder, nodes: Iterator[String]): Cluster.Builder = {
+      if (nodes.hasNext) {
+        val Array(ip, port) = nodes.next().split(':')
+        addNodes(builder.addContactPoint(ip), nodes)
+      } else {
+        builder
+      }
+    }
+
+    addNodes(Cluster.builder, nodes).build
+  }
+}
+
+class DirectSession(val nodes: List[String],
+  val timeout: Int,
+  val retryTime: Int) extends CassandraSessionDef {
+
+  val connectionPromise = Promise[Session]
+  val connection = connectionPromise.future
+  val cluster = buildCluster(nodes.iterator)
+  connectionPromise trySuccess cluster.connect
+
+  def close(): Unit = {
+  }
+
+  def force(): Unit = {
+  }
+}
+
+class ZookeeperSession(val zookeeperLocation: String,
+  val zNode: String,
+  val timeout: Int,
+  val retryTime: Int) extends CassandraSessionDef
+                         with NodeCacheListener
+                         with ConnectionStateListener {
+
+  import org.apache.curator.framework.{CuratorFrameworkFactory, CuratorFramework}
+  import org.apache.curator.framework.api.CuratorEvent
+  import org.apache.curator.framework.state.ConnectionState
+  import org.apache.curator.retry.RetryUntilElapsed
+  import com.datastax.driver.core.Cluster
+  import java.util.concurrent.Executors
+  import java.util.concurrent.TimeUnit.MILLISECONDS
+
+  val connectionPromise = Promise[Session]
+  val connection = connectionPromise.future
+
+  val zk = CuratorFrameworkFactory.newClient(zookeeperLocation, new RetryUntilElapsed(timeout, retryTime))
+  zk.getConnectionStateListenable.addListener(this)
+
+  val nodeCache = new NodeCache(zk, zNode)
+  nodeCache.getListenable.addListener(this)
+  zk.start()
+
+  val scheduler = Executors.newScheduledThreadPool(1)
+  val connectionTimeout = new Runnable {
+    override def run(): Unit = {
+      val failed = connectionPromise tryFailure (new SlickException("Could not make initial connection to zookeeper to retrieve cassandra configuration"))
+      if (failed) {
+        zk.close()
+      }
+    }
+  }
+  scheduler.schedule(connectionTimeout, timeout, MILLISECONDS)
+
+  def stateChanged(client: CuratorFramework, newState: ConnectionState): Unit = newState match {
+    case ConnectionState.CONNECTED |
+    ConnectionState.RECONNECTED => nodeCache.start()
+    case ConnectionState.LOST |
+    ConnectionState.SUSPENDED   => nodeCache.close()
+    case ConnectionState.READ_ONLY   => // Don't care
+  }
+
+  def nodeChanged: Unit = {
+    val data = new String(nodeCache.getCurrentData.getData)
+    val nodes = data.lines
+    val cluster = buildCluster(nodes)
+    connectionPromise trySuccess cluster.connect
+  }
+
+  def close(): Unit = {
+    if (connection.isCompleted)
+      Await.result(connection, Duration.Zero).close()
+    zk.close()
+  }
+
+  def force(): Unit = {
+  }
+}

--- a/slick/src/main/scala/slick/cassandra/CassandraTypesComponent.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraTypesComponent.scala
@@ -1,0 +1,39 @@
+package slick.cassandra
+import slick.relational.RelationalTypesComponent
+import slick.ast.{NumericTypedType, BaseTypedType}
+
+trait CassandraTypesComponent extends RelationalTypesComponent { self: CassandraProfile =>
+  object MappedCassandraType extends MappedColumnTypeFactory {
+    import scala.reflect.ClassTag
+    def base[T : ClassTag, U : BaseColumnType](tmap: T => U, tcomap: U => T): BaseColumnType[T] = ???
+  }
+
+  trait CassandraType[T] extends BaseTypedType[T] {
+    def classTag: scala.reflect.ClassTag[_] = ???
+    def scalaType: slick.ast.ScalaType[T] = ???
+  }
+
+  object CassandraBigDecimalColumnType extends CassandraType[BigDecimal] with NumericTypedType
+  object CassandraBooleanColumnType extends CassandraType[Boolean]
+  object CassandraByteColumnType extends CassandraType[Byte] with NumericTypedType
+  object CassandraCharColumnType extends CassandraType[Char]
+  object CassandraDoubleColumnType extends CassandraType[Double] with NumericTypedType
+  object CassandraFloatColumnType extends CassandraType[Float] with NumericTypedType
+  object CassandraIntColumnType extends CassandraType[Int] with NumericTypedType
+  object CassandraLongColumnType extends CassandraType[Long] with NumericTypedType
+  object CassandraShortColumnType extends CassandraType[Short] with NumericTypedType
+  object CassandraStringColumnType extends CassandraType[String]
+
+  trait ImplicitColumnTypes extends super.ImplicitColumnTypes {
+    implicit def bigDecimalColumnType = CassandraBigDecimalColumnType
+    implicit def booleanColumnType = CassandraBooleanColumnType
+    implicit def byteColumnType = CassandraByteColumnType
+    implicit def charColumnType = CassandraCharColumnType
+    implicit def doubleColumnType = CassandraDoubleColumnType
+    implicit def floatColumnType = CassandraFloatColumnType
+    implicit def intColumnType = CassandraIntColumnType
+    implicit def longColumnType = CassandraLongColumnType
+    implicit def shortColumnType = CassandraShortColumnType
+    implicit def stringColumnType = CassandraStringColumnType
+  }
+}


### PR DESCRIPTION
This is a basic first cut at the cassandra driver for Slick.  It implements enough to be able to create and drop a keyspace using a bare CQL query.  This is Slick's normal method for creating a new database.