### PR TITLE
Implement table creation

### DIFF
--- a/slick-testkit/src/main/resources/testkit-reference.conf
+++ b/slick-testkit/src/main/resources/testkit-reference.conf
@@ -46,6 +46,7 @@ testkit {
     ${testPackage}.TransactionTest
     ${testPackage}.UnionTest
     ${testPackage}.KeyspaceTest
+    ${testPackage}.TableCreationTest
   ]
 }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/KeyspaceCreationTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/KeyspaceCreationTest.scala
@@ -6,18 +6,15 @@ class KeyspaceTest extends AsyncTest[CassandraTestDB] {
   import tdb.profile.api._
 
   def testKeyspaceCreation = {
-    val command = "CREATE KEYSPACE IF NOT EXISTS slicktest WITH replication = {'class':'SimpleStrategy', 'replication_factor':1};"
-    val action = SimpleDBIO(_.connection.execute(command))
+    val dropIfCommand = "DROP KEYSPACE IF EXISTS slicktest;"
+    val dropCommand   = "DROP KEYSPACE slicktest;"
+    val createCommand = "CREATE KEYSPACE IF NOT EXISTS slicktest WITH replication = {'class':'SimpleStrategy', 'replication_factor':1};"
+    val dropIfAction  = SimpleDBIO(_.connection.execute(dropIfCommand))
+    val dropAction  = SimpleDBIO(_.connection.execute(dropCommand))
+    val createAction  = SimpleDBIO(_.connection.execute(createCommand))
+    val actions = DBIO.seq(dropIfAction, createAction, dropAction, createAction) // recreate at end for other tests
     for {
-      _ <- action
-    } yield ()
-  }
-
-  def testKeyspaceDrop = {
-    val command = "DROP KEYSPACE slicktest;"
-    val action = SimpleDBIO(_.connection.execute(command))
-    for {
-      _ <- action
+      _ <- actions
     } yield ()
   }
 }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TableCreationTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TableCreationTest.scala
@@ -7,12 +7,19 @@ class TableCreationTest extends AsyncTest[CassandraTestDB] {
 
   def testTableCreation = {
     class TestTable(tag: Tag) extends Table[Int](tag, "TEST") {
-      def id = column[Int]("ID")
+      def id = column[Int]("ID", O.PrimaryKey)
       def * = id
     }
     val testTable = TableQuery(new TestTable(_))
+    val check = "SELECT * FROM TEST;"
+    val cleanup = "DROP TABLE TEST;"
+    val checkAction = SimpleDBIO(_.connection.execute(check))
+    val cleanupAction = SimpleDBIO(_.connection.execute(cleanup))
+
     for {
       _ <- testTable.schema.create
+      _ <- checkAction
+      _ <- cleanupAction
     } yield ()
   }
 }

--- a/slick-testkit/src/test/scala/slick/test/unit/cassandra/TestCassandraColumnDDLBuilder.scala
+++ b/slick-testkit/src/test/scala/slick/test/unit/cassandra/TestCassandraColumnDDLBuilder.scala
@@ -1,0 +1,38 @@
+package test.scala.slick.test.unit.cassandra
+import org.scalatest._
+import Matchers._
+import org.scalamock.scalatest.MockFactory
+import slick.cassandra._
+import CassandraProfile._
+import slick.SlickException
+import slick.ast.{FieldSymbol, ColumnOption}
+
+class CassandraColumnDDLBuilderTests extends WordSpec with MockFactory {
+  "A Cassandra ColumnDDLBuilder" when {
+    "given an INT column that is not a primary key" should {
+      "have a toString of 'columnName int'" in {
+        val symbol = FieldSymbol("columnName")(Seq(), CassandraIntColumnType)
+        val builder = new ColumnDDLBuilder(symbol)
+        builder.toString shouldBe ("columnName int")
+      }
+    }
+
+    "given an INT column that is a primary key" should {
+      "have a toString of 'columnName int PRIMARY KEY'" in {
+        val symbol = FieldSymbol("columnName")(Seq(ColumnOption.PrimaryKey), CassandraIntColumnType)
+        val builder = new ColumnDDLBuilder(symbol)
+        builder.toString shouldBe ("columnName int PRIMARY KEY")
+      }
+    }
+
+    "given a column with an unsupported type" should {
+      "throw a SlickException" in {
+        val symbol = FieldSymbol("columnName")(Seq(), CassandraStringColumnType)
+        val thrown = intercept[SlickException] {
+          new ColumnDDLBuilder(symbol)
+        }
+        thrown.getMessage should startWith ("CassandraProfile has no CassandraType for type ")
+      }
+    }
+  }
+}

--- a/slick-testkit/src/test/scala/slick/test/unit/cassandra/TestCassandraDatabaseFactory.scala
+++ b/slick-testkit/src/test/scala/slick/test/unit/cassandra/TestCassandraDatabaseFactory.scala
@@ -17,6 +17,7 @@ class CassandraDatabaseFactoryTests extends WordSpec
         val config = ConfigFactory.parseString("""
           zookeeper = "127.0.0.1:2181"
           zNode     = "/cassandra"
+          keyspace  = "slicktest"
           timeout   = 0
           retryTime = 0
           """)
@@ -33,6 +34,7 @@ class CassandraDatabaseFactoryTests extends WordSpec
 
         val config = ConfigFactory.parseString("""
           nodes     = ["127.0.0.1:9042"]
+          keyspace  = "slicktest"
           timeout   = 0
           retryTime = 0
           """)
@@ -50,6 +52,7 @@ class CassandraDatabaseFactoryTests extends WordSpec
         val config = ConfigFactory.parseString("""
           zookeeper = "127.0.0.1:2181"
           nodes     = ["127.0.0.1:9042"]
+          keyspace  = "slicktest"
           timeout   = 0
           retryTime = 0
           """)

--- a/slick-testkit/src/test/scala/slick/test/unit/cassandra/TestCassandraTableDDL.scala
+++ b/slick-testkit/src/test/scala/slick/test/unit/cassandra/TestCassandraTableDDL.scala
@@ -1,0 +1,30 @@
+package test.scala.slick.test.unit.cassandra
+import org.scalatest._
+import Matchers._
+import org.scalamock.scalatest.MockFactory
+import slick.cassandra._
+import CassandraProfile.api._
+import slick.SlickException
+import slick.ast.{FieldSymbol, ColumnOption}
+import slick.lifted.BaseTag
+
+class CassandraTableDDLTests extends WordSpec with MockFactory {
+  "A Cassandra TableDDL" when {
+    "given a single INT column that is a primary key" should {
+      "have a createPhase1 of 'Iterable('CREATE TABLE TableName (ColumnName int PRIMARY KEY');'" in {
+        class TestTable(tag: slick.lifted.Tag) extends Table[(Int)](tag, "TableName") {
+          def id = column[Int]("ColumnName", O.PrimaryKey)
+
+          def * = (id)
+        }
+
+        val table = new TestTable(null)
+        val ddl = new CassandraTableDDL(table)
+        ddl.createPhase1 should contain ("CREATE TABLE TableName (ColumnName int PRIMARY KEY);")
+      }
+    }
+  }
+
+  //Note:  Negative tests and other column and primary key configurations will
+  //       be handled in the next user story.
+}

--- a/slick/src/main/scala/slick/cassandra/CassandraActionComponent.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraActionComponent.scala
@@ -77,7 +77,8 @@ trait CassandraActionComponent extends SqlActionComponent { self: CassandraProfi
   class SchemaActionExtensionMethodsImpl(schema: SchemaDescription) extends super.SchemaActionExtensionMethodsImpl {
     /** Create an Action that creates the entities described by this schema description. */
     def create: ProfileAction[Unit, NoStream, Effect.Schema] = new CassandraAction[Unit]("schema.create", schema.createStatements.toVector) {
-      def run(ctx: Backend#Context, sql: Vector[String]): Unit = {
+      def run(ctx: Backend#Context, cql: Vector[String]): Unit = {
+        for(c <- cql) ctx.session.run(c)
       }
     }
 

--- a/slick/src/main/scala/slick/cassandra/CassandraBackend.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraBackend.scala
@@ -47,6 +47,10 @@ trait CassandraBackend extends RelationalBackend
     *                     cassandra config.  Defaults to '127.0.0.1:2181'
     * zNode:              zNode containing location of cassandra nodes in
     *                     zookeeper. defaults to '/cassandra'
+    * keyspace:           The keyspace for the session.  This is optional, but
+    *                     if omitted, you will have to manually create and
+    *                     'USE keyspace' using plain CQL queries before
+    *                     using the higher-level API.
     * timeout:            milliseconds to wait for connection before aborting.
     *                     Defaults to 60000.
     * retryTime:          milliseconds to wait between connection retries.
@@ -66,29 +70,32 @@ trait CassandraBackend extends RelationalBackend
   class ZookeeperDatabaseDef(override val executor: AsyncExecutor,
                              override val zookeeperLocation: String,
                              override val zNode: String,
+                             override val keyspace: Option[String],
                              override val timeout: Int,
                              override val retryTime: Int)
-    extends ZookeeperDatabase(executor, zookeeperLocation, zNode, timeout, retryTime)
+    extends ZookeeperDatabase(executor, zookeeperLocation, zNode, keyspace, timeout, retryTime)
     with DatabaseDef
 
   class DirectDatabaseDef(override val executor: AsyncExecutor,
                           override val nodes: List[String],
+                          override val keyspace: Option[String],
                           override val timeout: Int,
                           override val retryTime: Int)
-    extends DirectDatabase(executor, nodes, timeout, retryTime)
+    extends DirectDatabase(executor, nodes, keyspace, timeout, retryTime)
     with DatabaseDef
 
   trait SessionDef extends CassandraSessionDef with super.SessionDef
 
   class ZookeeperSessionDef (override val zookeeperLocation: String,
                              override val zNode: String,
+                             override val keyspace: Option[String],
                              override val timeout: Int,
                              override val retryTime: Int)
-    extends ZookeeperSession(zookeeperLocation, zNode, timeout, retryTime)
+    extends ZookeeperSession(zookeeperLocation, zNode, keyspace, timeout, retryTime)
     with SessionDef
 
-  class DirectSessionDef (override val nodes: List[String])
-    extends    DirectSession(nodes)
+  class DirectSessionDef (override val nodes: List[String], override val keyspace: Option[String])
+    extends    DirectSession(nodes, keyspace)
     with SessionDef
 
   /** The context object passed to database actions by the execution engine. */

--- a/slick/src/main/scala/slick/cassandra/CassandraDatabaseFactory.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraDatabaseFactory.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.ConfigFactory
 import scala.collection.convert.wrapAll._
 import slick.util.AsyncExecutor
 import slick.SlickException
+import scala.util.Try
 
 trait CassandraDatabaseFactory {self: CassandraBackend =>
   trait DatabaseFactoryDef {
@@ -12,17 +13,18 @@ trait CassandraDatabaseFactory {self: CassandraBackend =>
       val usedConfig = if (path.isEmpty) config else config.getConfig(path)
       val timeout = usedConfig.getInt("timeout")
       val retryTime = usedConfig.getInt("retryTime")
+      val keyspace: Option[String] = Try(usedConfig.getString("keyspace")).toOption
 
       if (usedConfig.hasPath("nodes") && usedConfig.hasPath("zookeeper"))
         throw new SlickException("Config cannot contain both zookeeper node and direct cassandra entries.")
 
       if (usedConfig.hasPath("nodes")) {
         val nodes = usedConfig.getStringList("nodes").toList
-        new self.DirectDatabaseDef(AsyncExecutor.default(), nodes, timeout, retryTime)
+        new self.DirectDatabaseDef(AsyncExecutor.default(), nodes, keyspace, timeout, retryTime)
       } else {
         val zookeeperLocation = usedConfig.getString("zookeeper")
         val zNode = usedConfig.getString("zNode")
-        new self.ZookeeperDatabaseDef(AsyncExecutor.default(), zookeeperLocation, zNode, timeout, retryTime)
+        new self.ZookeeperDatabaseDef(AsyncExecutor.default(), zookeeperLocation, zNode, keyspace, timeout, retryTime)
       }
     }
   }

--- a/slick/src/main/scala/slick/cassandra/CassandraDatabases.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraDatabases.scala
@@ -21,12 +21,13 @@ trait CassandraDatabases {self: CassandraBackend =>
   class ZookeeperDatabase(override val executor: AsyncExecutor,
     val zookeeperLocation: String,
     val zNode: String,
+    val keyspace: Option[String],
     val timeout: Int,
     val retryTime: Int) extends CassandraDatabase(executor) {
 
     /** Create a new session. The session needs to be closed explicitly by calling its close() method. */
     def createSession(): Session = {
-      new ZookeeperSessionDef(zookeeperLocation, zNode, timeout, retryTime)
+      new ZookeeperSessionDef(zookeeperLocation, zNode, keyspace, timeout, retryTime)
     }
 
     def close: Unit = {
@@ -37,12 +38,13 @@ trait CassandraDatabases {self: CassandraBackend =>
     * list of cassandra nodes directly. */
   class DirectDatabase(override val executor: AsyncExecutor,
     val nodes: List[String],
+    val keyspace: Option[String],
     val timeout: Int,
     val retryTime: Int) extends CassandraDatabase(executor) {
 
     /** Create a new session. The session needs to be closed explicitly by calling its close() method. */
     def createSession(): Session = {
-      new DirectSessionDef(nodes)
+      new DirectSessionDef(nodes, keyspace)
     }
 
     def close: Unit = {

--- a/slick/src/main/scala/slick/cassandra/CassandraProfile.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraProfile.scala
@@ -60,21 +60,7 @@ trait CassandraProfile extends SqlProfile with CassandraActionComponent
     def dropPhase2: Iterable[String] = ???
   }
 
-  class TableDDL(val table: Table[_]) extends super.DDL {
-    val columns: Iterable[FieldSymbol] = table.create_*
-    val tableNode = table.tableNode
-
-    def createPhase1: Iterable[String] = {
-      val name = quoteTableName(tableNode)
-      val columns = "test int PRIMARY KEY"
-      val cql = "CREATE TABLE " + name + "(" + columns + ");"
-      println(cql)
-      Iterable(cql)
-    }
-    def createPhase2: Iterable[String] = Iterable()
-    def dropPhase1: Iterable[String] = ???
-    def dropPhase2: Iterable[String] = ???
-  }
+  class TableDDL(override val table: Table[_]) extends CassandraTableDDL(table) with super.DDL
 }
 
 object CassandraProfile extends CassandraProfile {

--- a/slick/src/main/scala/slick/cassandra/CassandraTableDDL.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraTableDDL.scala
@@ -1,0 +1,15 @@
+package slick.cassandra
+
+class CassandraTableDDL(val table: CassandraProfile#Table[_]) {
+  val columns: Iterable[String] = table.create_*.map(column => new ColumnDDLBuilder(column)).map(_.toString)
+  val tableNode = table.tableNode
+
+  def createPhase1: Iterable[String] = {
+    val name = tableNode.tableName
+    val cql = "CREATE TABLE " + name + " (" + columns.mkString(", ") + ");"
+    Iterable(cql)
+  }
+  def createPhase2: Iterable[String] = Iterable()
+  def dropPhase1: Iterable[String] = ???
+  def dropPhase2: Iterable[String] = ???
+}

--- a/slick/src/main/scala/slick/cassandra/CassandraType.scala
+++ b/slick/src/main/scala/slick/cassandra/CassandraType.scala
@@ -1,0 +1,32 @@
+package slick.cassandra
+
+import slick.ast.{BaseTypedType, Type, ScalaBaseType}
+import scala.reflect.ClassTag
+import slick.SlickException
+
+/** A CassandraType object represents a Scala type that can be used as a column type in the database. */
+trait CassandraType[@specialized(Int) T] extends BaseTypedType[T] { self =>
+  /** The default name for the CQL type that is used for column declarations. */
+  def cqlTypeName: String
+
+  override def toString = scalaType.toString + "'"
+}
+
+abstract class DriverCassandraType[@specialized T](implicit val classTag: ClassTag[T]) extends CassandraType[T] {
+  def scalaType = ScalaBaseType[T]
+}
+
+class IntCassandraType extends DriverCassandraType[Int] {
+  def cqlTypeName = "int"
+}
+
+object CassandraType {
+  def unapply(t: Type) = Some(cassandraTypeFor(t))
+
+  val intCassandraType = new IntCassandraType
+
+  def cassandraTypeFor(t: Type): CassandraType[Any] = ((t.structural match {
+    case CassandraProfile.CassandraIntColumnType => intCassandraType
+    case t                                       => throw new SlickException("CassandraProfile has no CassandraType for type " + t)
+  }): CassandraType[_]).asInstanceOf[CassandraType[Any]]
+}

--- a/slick/src/main/scala/slick/cassandra/ColumnDDLBuilder.scala
+++ b/slick/src/main/scala/slick/cassandra/ColumnDDLBuilder.scala
@@ -1,0 +1,13 @@
+package slick.cassandra
+import slick.ast._
+import slick.sql.SqlProfile
+
+class ColumnDDLBuilder(column: FieldSymbol) {
+  val primaryKey = column.options contains ColumnOption.PrimaryKey
+  val CassandraType(cassandraType) = column.tpe
+
+  override def toString: String = {
+    val primaryKeyString = if (primaryKey) " PRIMARY KEY" else ""
+    column.name + " " + cassandraType.cqlTypeName + primaryKeyString
+  }
+}


### PR DESCRIPTION
Limitations:

- One column only (probably will do more, but is untested because it was out of scope).
- Integer columns only.
- Must be primary key.
- Not all these constraints are enforced by the code, since we will be changing them in the next story.

Also added the ability to configure the keyspace for the session, and fixed some keyspace negative tests that were erroneously passing due to timeouts rather than their real reasons.